### PR TITLE
feat: [v0.1.0] add subscribe method to form-field-chaining

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
     branches:
       - main
+    types: 
+      - closed  # PR이 병합될 때만 실행되도록 설정
 
 jobs:
   publish-npm:
+    if: github.event.pull_request.merged == true  # PR이 병합되었을 때만 실행
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -65,13 +65,14 @@ This form system enhances productivity with TypeScript IDE support, simplifies d
 
 ### Controller
 
-| Target        | Description                                                                                      | Type                                                     |
-|---------------|--------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| setValue      | Update the value of a specific field                                                             | `(key: TKey, value: TFormModel[TKey]) => void`             |
-| setValues     | Update the entire model                                                                          | `(values: TFormModel) => void`                             |
-| validate      | Validate a specific field                                                                        | `(key: TKey) => boolean`                                   |
-| validateAll   | Validate all fields                                                                              | `(key: TKey, value: TFormModel[TKey]) => boolean`          |
-| undo          | Undo the update (experimental)                                                                   | `() => void`                                               |
-| reset         | Reset the form                                                                                   | `() => void`                                               |
-| read          | Fetch data from the server, convert to the model, and set the form                               | `(data: DataResponse) => void`                             |
-| write         | Convert model data to the interface expected by the server                                       | `() => WriteResult(server expected data)`                  |
+| Target        | Description                            | Type                                                     |
+|---------------|----------------------------------------|----------------------------------------------------------|
+| setValue      | Updates the value of a specific field  | `(key: TKey, value: TFormModel[TKey]) => void`  |
+| setValues     | Updates the entire form model    | `(values: TFormModel) => void` |
+| validate      | Validates a specific field       | `(key: TKey) => boolean` |
+| validateAll   | Validates all fields             | `(key: TKey, value: TFormModel[TKey]) => boolean` |
+| undo          | Undoes the last update (experimental)  | `() => void` |
+| reset         | Resets the form to its initial state   | `() => void` |
+| subscribe     | Subscribes to changes in specific form values. Listens for changes in the specified keys and triggers the provided callback function when those values change.  | `(keys: TKey[], listener: (values: Pick<NonNullable<TFormModel>, TKey>) => void`  |
+| read          | Fetches data from the server, converts it to the model format, and sets the form   | `(data: DataResponse) => void` |
+| write         | Converts model data to the format expected by the server   | `() => WriteResult(server expected data)`  |

--- a/demo/react-form-model-controller/src/App/NameFixer.tsx
+++ b/demo/react-form-model-controller/src/App/NameFixer.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { useFormOne } from "./model_and_hook"
+
+const NameFixer: React.FC = () => {
+    const { controller } = useFormOne();
+
+    useEffect(() => {
+        const unsub = controller.subscribe(['name'], (values) => {
+            if (values.name === 'son') {
+                controller.setValue('age', '30');
+            }
+            if (values.name === 'dad') {
+                controller.setValue('age', '60');
+            }
+        })
+        return () => { unsub() }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    return null;
+}
+export default NameFixer;

--- a/demo/react-form-model-controller/src/App/index.tsx
+++ b/demo/react-form-model-controller/src/App/index.tsx
@@ -3,6 +3,7 @@ import { useFormOne } from './model_and_hook';
 import DUMMY_API from './api';
 import { validateAge, validateName, validateCities } from './validator';
 import { ModalUtils } from './ModalUtils';
+import NameFixer from './NameFixer';
 
 interface DemoAction {
   name: string;
@@ -56,57 +57,60 @@ const App: React.FC = () => {
   ];
 
   return (
-    <Flex align="center" justify="center" style={{ width: '100%', minWidth: 1300, height: '100%' }} gap={16}>
-      <Flex vertical align="center" justify="center" gap={8} style={{ minWidth: 600, width: 600, marginTop: 38, }}>
-        <Card type="inner" title="Forms" style={{ width: '100%' }}>
-          <Flex vertical gap={30}>
-            <Field name="name" validator={validateName}>
-              {({ value, error, fieldHandler }) => (
-                <Flex vertical style={{ position: 'relative' }}>
-                  <label>name</label>
-                  <Input value={value} onChange={fieldHandler} />
-                  {error && <div style={{ color: 'red', position: 'absolute', top: 55 }}>{error}</div>}
-                </Flex>
-              )}
-            </Field>
-            <Field name="age" validator={validateAge}>
-              {({ value, error, fieldHandler }) => (
-                <Flex vertical style={{ position: 'relative' }}>
-                  <label>age</label>
-                  <Input value={value} onChange={fieldHandler} />
-                  {error && <div style={{ color: 'red', position: 'absolute', top: 55 }}>{error}</div>}
-                </Flex>
-              )}
-            </Field>
-            <Field name="cities" validator={validateCities}>
-              {({ value, error, fieldHandler }) => (
-                <Flex vertical style={{ position: 'relative', paddingBottom: 20 }}>
-                  <label>cities</label>
-                  <Select
-                    value={value}
-                    mode="multiple"
-                    style={{ width: '100%' }}
-                    placeholder="select one country"
-                    onChange={fieldHandler}
-                    options={['seoul', 'daejeon', 'sejong'].map((nation) => ({
-                      label: nation,
-                      value: nation,
-                    }))}
-                  />
-                  {error && <div style={{ color: 'red', position: 'absolute', top: 55 }}>{error}</div>}
-                </Flex>
-              )}
-            </Field>
-          </Flex>
-        </Card>
-        <Table columns={columns} dataSource={data} pagination={false} rowKey={(a) => a.name} />;
+    <>
+      <NameFixer />
+      <Flex align="center" justify="center" style={{ width: '100%', minWidth: 1300, height: '100%' }} gap={16}>
+        <Flex vertical align="center" justify="center" gap={8} style={{ minWidth: 600, width: 600, marginTop: 38, }}>
+          <Card type="inner" title="Forms" style={{ width: '100%' }}>
+            <Flex vertical gap={30}>
+              <Field name="name" validator={validateName}>
+                {({ value, error, fieldHandler }) => (
+                  <Flex vertical style={{ position: 'relative' }}>
+                    <label>name</label>
+                    <Input value={value} onChange={fieldHandler} />
+                    {error && <div style={{ color: 'red', position: 'absolute', top: 55 }}>{error}</div>}
+                  </Flex>
+                )}
+              </Field>
+              <Field name="age" validator={validateAge}>
+                {({ value, error, fieldHandler }) => (
+                  <Flex vertical style={{ position: 'relative' }}>
+                    <label>age</label>
+                    <Input value={value} onChange={fieldHandler} />
+                    {error && <div style={{ color: 'red', position: 'absolute', top: 55 }}>{error}</div>}
+                  </Flex>
+                )}
+              </Field>
+              <Field name="cities" validator={validateCities}>
+                {({ value, error, fieldHandler }) => (
+                  <Flex vertical style={{ position: 'relative', paddingBottom: 20 }}>
+                    <label>cities</label>
+                    <Select
+                      value={value}
+                      mode="multiple"
+                      style={{ width: '100%' }}
+                      placeholder="select one country"
+                      onChange={fieldHandler}
+                      options={['seoul', 'daejeon', 'sejong'].map((nation) => ({
+                        label: nation,
+                        value: nation,
+                      }))}
+                    />
+                    {error && <div style={{ color: 'red', position: 'absolute', top: 55 }}>{error}</div>}
+                  </Flex>
+                )}
+              </Field>
+            </Flex>
+          </Card>
+          <Table columns={columns} dataSource={data} pagination={false} rowKey={(a) => a.name} />;
+        </Flex>
+        <Image
+          src="https://github.com/cicada1992/react-form-model-controller/raw/main/assets/model-basic.png"
+          style={{ minWidth: 650 }}
+          height={750}
+        />
       </Flex>
-      <Image
-        src="https://github.com/cicada1992/react-form-model-controller/raw/main/assets/model-basic.png"
-        style={{ minWidth: 650 }}
-        height={750}
-      />
-    </Flex>
+    </>
   );
 
   async function read() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-form-model-controller",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/react-form-model-controller/README.md
+++ b/packages/react-form-model-controller/README.md
@@ -39,7 +39,10 @@ This form system enhances productivity with TypeScript IDE support, simplifies d
 2. Use created hook in your component.
 ![basic-component](https://github.com/cicada1992/react-form-model-controller/raw/main/assets/component-basic.png)
 
-## APIs
+## Caveat
+- Check your codebase settings(env) for decorator syntax.
+
+## APIS
 ### Field Component Props
 
 | Target           | Description                                                                                       | Type                                      | Required  |
@@ -62,17 +65,14 @@ This form system enhances productivity with TypeScript IDE support, simplifies d
 
 ### Controller
 
-| Target        | Description                                                                                      | Type                                                     |
-|---------------|--------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| setValue      | Update the value of a specific field                                                             | `(key: TKey, value: TFormModel[TKey]) => void`             |
-| setValues     | Update the entire model                                                                          | `(values: TFormModel) => void`                             |
-| validate      | Validate a specific field                                                                        | `(key: TKey) => boolean`                                   |
-| validateAll   | Validate all fields                                                                              | `(key: TKey, value: TFormModel[TKey]) => boolean`          |
-| undo          | Undo the form update (experimental)                                                                   | `() => void`                                               |
-| reset         | Reset the form                                                                                   | `() => void`                                               |
-| read          | Fetch data from the server, convert to the model, and set the form                               | `(data: DataResponse) => void`                             |
-| write         | Convert model data to the interface expected by the server                                       | `() => WriteResult(server expected data)`                  |
-
-
-## Caveat
-- Check your codebase settings(env) for decorator syntax.
+| Target        | Description                            | Type                                                     |
+|---------------|----------------------------------------|----------------------------------------------------------|
+| setValue      | Updates the value of a specific field  | `(key: TKey, value: TFormModel[TKey]) => void`  |
+| setValues     | Updates the entire form model    | `(values: TFormModel) => void` |
+| validate      | Validates a specific field       | `(key: TKey) => boolean` |
+| validateAll   | Validates all fields             | `(key: TKey, value: TFormModel[TKey]) => boolean` |
+| undo          | Undoes the last update (experimental)  | `() => void` |
+| reset         | Resets the form to its initial state   | `() => void` |
+| subscribe     | Subscribes to changes in specific form values. Listens for changes in the specified keys and triggers the provided callback function when those values change.  | `(keys: TKey[], listener: (values: Pick<NonNullable<TFormModel>, TKey>) => void`  |
+| read          | Fetches data from the server, converts it to the model format, and sets the form   | `(data: DataResponse) => void` |
+| write         | Converts model data to the format expected by the server   | `() => WriteResult(server expected data)`  |

--- a/packages/react-form-model-controller/package.json
+++ b/packages/react-form-model-controller/package.json
@@ -52,6 +52,7 @@
     "vite-plugin-dts": "^3.9.1"
   },
   "dependencies": {
+    "deep-object-diff": "^1.1.9",
     "deepmerge": "^4.3.1",
     "lodash.clone": "^4.5.0",
     "lodash.isempty": "^4.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
 
   packages/react-form-model-controller:
     dependencies:
+      deep-object-diff:
+        specifier: ^1.1.9
+        version: 1.1.9
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1534,6 +1537,10 @@ packages:
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
+
+  /deep-object-diff@1.1.9:
+    resolution: {integrity: sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==}
+    dev: false
 
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}


### PR DESCRIPTION
## Changes
The subscribe method has been added to the controller for form field chaining.

## Usage Example
> “The example shown in the image is in the demo code.”
<img width="462" alt="image" src="https://github.com/user-attachments/assets/d9f9af3a-58c9-4a54-be40-4573c8cee265" />